### PR TITLE
Include missing packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cache-dependencies"
-version = "0.7.7.49"
+version = "0.7.7.50"
 description = "Cache-dependencies (former Cache-tagging) allows you easily invalidate all cache records tagged with a given tag(s). Supports Django."
 authors = ["Ivan Zakrevsky <ivzak@yandex.ru>"]
 license = "BSD-1-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ version = "0.7.7.49"
 description = "Cache-dependencies (former Cache-tagging) allows you easily invalidate all cache records tagged with a given tag(s). Supports Django."
 authors = ["Ivan Zakrevsky <ivzak@yandex.ru>"]
 license = "BSD-1-Clause"
+packages = [
+    { include = "cache_dependencies" },
+    { include = "cache_tagging" },
+    { include = "django_cache_dependencies" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
The current project structure differs from poetry standard one and based on [documentation](https://python-poetry.org/docs/pyproject/#packages), any extra package needs to be specified.